### PR TITLE
Allow linebreaks in the `prefix` attribute

### DIFF
--- a/grammar/rash-html.rng
+++ b/grammar/rash-html.rng
@@ -27,8 +27,8 @@ Under the following terms:
         <element name="html">
             <attribute name="prefix">
                 <data type="string">
-                    <param name="pattern">.*schema:\s+http://schema.org/.*</param>
-                    <param name="pattern">.*prism:\s+http://prismstandard.org/namespaces/basic/2.0/.*</param>
+                    <param name="pattern">[\s\S]*schema:\s+http://schema.org/[\s\S]*</param>
+                    <param name="pattern">[\s\S]*prism:\s+http://prismstandard.org/namespaces/basic/2.0/[\s\S]*</param>
                 </data>
             </attribute>
             <ref name="attributes_html_generic" />


### PR DESCRIPTION
In the XSD regex flavor, `.*` will not match linebreaks. If you want to allow linebreaks in the value, you have to do `[\s\S]` instead.