### PR TITLE
Add support for AsciiMath formulas

### DIFF
--- a/js/rash.js
+++ b/js/rash.js
@@ -300,25 +300,48 @@ var listingbox_selector_pre = "pre";
 var listingbox_selector = "figure > " + listingbox_selector_pre;
 
 $(function() {
-    /* LaTeX formulas */
+    /* AsciiMath and LaTeX formulas */
     if (typeof MathJax !== 'undefined') {
-        var s_delim = 's$s';
-        var e_delim = 'e$e';
-        $('body').attr("class", "nomath");
+      // MathJax should parse *only* math content within span with role=math
+      var ignore_math_class = 'rash-nomath';
+      var process_math_class = 'rash-math';
+              $('body').attr("class", ignore_math_class);
+      var ascii_math_left_delimiter = '``';
+      var ascii_math_right_delimiter = '``';
+                var tex_math_left_delimiter = '$$';
+          var tex_math_right_delimiter = '$$';
         $('span[role=math]').each(function() {
-            $(this).attr("class", "math");
-            $(this).html(s_delim + $(this).html() + e_delim);
+          //We need to keep the outer span to let MathJax know that it should process its content
+          // but we *must* absolutely change its role.
+          $(this).attr("role", "presentation");
+          $(this).attr("class", process_math_class);
+            var tex_math_regex = /\\.+(?![\ ])/g;
+          if(tex_math_regex.test($(this).text())) {
+                        $(this).html(tex_math_left_delimiter+$(this).html()+tex_math_right_delimiter);
+          }
+          else {
+                        $(this).html(ascii_math_left_delimiter+$(this).html()+ascii_math_right_delimiter);
+          }
         });
         MathJax.Hub.Config({
+          asciimath2jax: {
+            // delimiters for AsciiMath formulas
+            delimiters: [ [ascii_math_left_delimiter, ascii_math_right_delimiter] ],
+              processClass: process_math_class,
+              ignoreClass: ignore_math_class
+          },
             tex2jax: {
-                inlineMath: [ [s_delim, e_delim] ],
-                processClass: "math",
-                ignoreClass: "nomath"
+              // delimiters for LaTeX formulas
+                inlineMath: [ [tex_math_left_delimiter, tex_math_right_delimiter] ],
+                processClass: process_math_class,
+                ignoreClass: ignore_math_class
             }
         });
+        // we changed the DOM, so we make MathJax typeset the document again.
+                MathJax.Hub.Queue([ "Typeset", MathJax.Hub ]);
     }
-    /* /END LaTeX formulas */
-    
+    /* /END AsciiMath and LaTeX formulas */
+
     /* Code Block */
     $('pre').each(function() {
         $(this).html($.trim($(this).html()))

--- a/tools/math2mathml/README.md
+++ b/tools/math2mathml/README.md
@@ -1,0 +1,17 @@
+# Math2Mathml
+
+The math2mathml.js script converts a (valid) RASH document replacing Math Formulas (defined using both LaTeX and AsciiMath notation) with their MathML equivalent and saves the converted document to the specified path.
+
+
+## Usage
+
+After opening a terminal and entering the RASH folder, using the math2mathml script is as simple as typing `phantomjs math2mathml.js -o output_path document_path"` where
+* output_path is the path where you want to save the converted document and
+* document_path is the path of the document you want to convert.
+
+Please note that in order to use this script you need a working network connection as RASH loads MathJax dynamically over the Internet.
+
+
+## Dependencies
+
+In order to execute math2mathml.js you have to install [PhantomJS](http://phantomjs.org/). You also need a handful more dependencies (notably MathJax and JQuery) but you shouldn't worry about them since they are automatically taken care of by the RASH framework which embeds them in RASH documents as needed.

--- a/tools/math2mathml/math2mathml.js
+++ b/tools/math2mathml/math2mathml.js
@@ -1,0 +1,128 @@
+/*
+ * math2mathml.js - Version 0.1, August 30, 2016
+ * Copyright (c) 2016, Vincenzo Rubano <vincenzorubano@email.it>
+ * 
+ * Permission to use, copy, modify, and/or distribute this software for any purpose with 
+ * or without fee is hereby granted, provided that the above copyright notice and this 
+ * permission notice appear in all copies.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD 
+ * TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. 
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR 
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR 
+ * PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING 
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */var fs = require('fs');
+
+
+var page = require('webpage').create();
+var sys = require('system');
+
+phantom.onError = errorHandler
+page.onError = errorHandler
+// By default, PhantomJS won't display messages logged to the console by the web page.
+// However those messages might be incredibly useful for debugging, so we change this behavior.
+page.onConsoleMessage = function(msg) {
+  console.log("WebPage said: "+msg+"\n");
+}
+// we need to route a callback from the document context to the Phantom context
+page.onCallback = function(data) {
+  if(data.reason === 'finishedRenderingMath') {
+    onFinishedRenderingMath();
+  }
+}
+//Performance tweak: prevent css stylesheets from loading
+page.onResourceRequested = function(requestData, request) {
+    if ((/.+\.css$/gi).test(requestData['url'])) {
+        request.abort();
+    }   
+}
+//Performance tweak: disable image loading
+page.settings.loadsImages = false
+
+var outputPath;
+var documentPath;
+  if(sys.args[1] == "-h" || sys.args[1] == "--help") {
+      usage("Converts Math notation, both AsciiMath and LaTeX, in a RASH document into its MathML equivalent.\n\n");
+  }
+else if(sys.args.length < 4) {
+      usage("Too few arguments given.");
+}
+else if(sys.args.length>4) {
+  usage("Too many arguments given.");
+}
+else {
+  if(sys.args[1] == "-o" || sys.args[1] == "--output") {
+    outputPath = sys.args[2];
+    documentPath = sys.args[3];
+  }
+  else {
+    usage("Invalid argument "+sys.args[1]+".");
+  }
+}
+
+page.open(documentPath, function(status) {
+  if(status === 'success') {
+    page.evaluate(function() {
+      MathJax.Hub.Queue(function() {
+        // we need to cleanup the markup a bit.
+        // RASH depends on JQuery, so we can leverage it here as well.
+        // We remove all elements with the "cgen" class, introduced automatically by RASH.
+        $('.cgen').remove();
+        // The MathJax output for each formula is really complex, but we are only interested in its internal MathML.
+        // While MathJax offers a method to retrieve the MathML equivalent of a formula, it can unpredictably behave syncronously or asyncronously. This uncertainty makes its usage for our purpose problematic, so we extract the MathML equivalent of each formula manually.
+        var mathContainers = $('.rash-math');
+        var mathmlElements = $('.MJX_Assistive_MathML math');
+        for(var i=0;i<mathmlElements.length;i++) {
+          mathContainers.eq(i).replaceWith(mathmlElements.eq(i));
+        }
+        // MathJax adds a lot of inline stylesheets that we don't need, so we remove them all
+        $('head style').remove();
+                window.callPhantom({
+          reason: "finishedRenderingMath"
+        });
+        });
+    });
+  }
+  else {
+    console.error("Error while loading the document. Status: "+status+"\n");
+    phantom.exit(1);
+  }
+});
+
+function onFinishedRenderingMath() {
+  try {
+    fs.write(outputPath, page.content, "w");
+    phantom.exit();
+  }
+  catch(error) {
+    console.error("Error while saving file. "+error);
+    phantom.exit(1);
+  }
+}
+
+/*
+  * JavaScript error handler.
+  * This handler can be triggered for both global errors or page specific ones.
+*/
+function errorHandler(msg, trace) {
+    console.log(msg);
+    trace.forEach(function(item) {
+        console.log('  ', item.file, ':', item.line);
+    });
+  phantom.exit(1);
+}
+
+/**
+  * Prints usage information to the console and stops execution.
+*/
+function usage(reason) {
+  if(reason) {
+    console.log(reason+"\n\n");
+  }
+  var help = "Usage:\n\nmath2mathml.js ";
+  help += "-o output_path,\t path where the converted document will be saved\n";
+  help += "document\t, Path of a RASH document containing AsciiMath notation that you want to convert.";
+  console.log(help);
+  phantom.exit(1);
+}


### PR DESCRIPTION
This PR adds support for defining Math formulas in a RASH document using the [AsciiMath](http://asciimath.org) notation. It also provides a [PhantomJS](http://phantomjs.org) script to convert all Math formulas in a RASH document into their MathML equivalent.